### PR TITLE
Use the latest nodejs-base image which fixes issues with the centos-b…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ukhomeofficedigital/nodejs-base:v6.11.1
+FROM quay.io/ukhomeofficedigital/nodejs-base:v8.11.1
 
 ENV PTTG_API_ENDPOINT localhost
 ENV USER pttg


### PR DESCRIPTION
…ase image.