### PR TITLE
EE-3725 Error messages displayed to user

### DIFF
--- a/features/feature_files/7-consent/FS7-4-consent-errors.feature
+++ b/features/feature_files/7-consent/FS7-4-consent-errors.feature
@@ -50,3 +50,13 @@ Feature: Handle the errors and bad request responses from the Barclays Consent A
             | 500    |
             | 501    |
             | 599    |
+
+    Scenario: Consent response indicates an error not covered by specific cases
+        Given the api health check response has status 200
+        And the api consent response will be ERROR
+        And the api threshold response will be t4
+        And caseworker is on page t4/application/status/main/general
+        And the financial status check is performed
+        Then the service displays the following result
+            | Outcome        | Error                                         |
+            | Outcome detail | Mobile number has been updated within 14 days |

--- a/features/test-data/consentcheckresponse-ERROR.json
+++ b/features/test-data/consentcheckresponse-ERROR.json
@@ -1,0 +1,7 @@
+{
+  "consent" : "ERROR",
+  "status" : {
+    "code" : "470",
+    "message" : "Mobile number has been updated within 14 days"
+  }
+}

--- a/features/test-data/dailyBalanceFail-error.json
+++ b/features/test-data/dailyBalanceFail-error.json
@@ -1,0 +1,11 @@
+{
+    "accountHolderName" : "Ray Purchase",
+    "pass" : false,
+    "failureReason" : {
+        
+    },
+    "status" : {
+        "code" : "470",
+        "message" : "Mobile number has been updated within 14 days"
+    }
+}

--- a/src/app/modules/forms/forms.js
+++ b/src/app/modules/forms/forms.js
@@ -491,6 +491,9 @@ formsModule.directive('hodRadio', ['FormsService', function (FormsService) {
         scope.validfunc = function (val) {
           var selected = scope.getSelectedOption(val)
           var validate = function () {
+            if (_.isObject(scope.config.validate)) {
+              return scope.config.validate(scope.config.options, scope)
+            }
             if (scope.config.required && _.isUndefined(selected)) {
               // it is required (do this test before val is still a string)
               scope.getInput().$valid = false

--- a/src/app/modules/fs/controllers/fsGetConsent.js
+++ b/src/app/modules/fs/controllers/fsGetConsent.js
@@ -90,6 +90,7 @@ fsModule.controller('FsGetConsentResultCtrl', ['$scope', '$state', 'FsService', 
   }
 
   var consentStatus = FsBankService.getConsentStatus(fs)
+  console.log('ERROR')
   FsService.track('consent', consentStatus, 'consent-only')
   switch (consentStatus) {
     case 'INITIATED':
@@ -110,22 +111,28 @@ fsModule.controller('FsGetConsentResultCtrl', ['$scope', '$state', 'FsService', 
       $scope.outcome = FsInfoService.t('consentDenied')
       $scope.outcomeDetail = FsInfoService.t('consentDeniedReason')
       break
-
     case 500:
       $scope.outcome = FsInfoService.t('notnow')
       $scope.outcomeDetail = FsInfoService.t('trylater')
       break
 
     default:
-      $scope.outcome = FsInfoService.t('inaccessibleaccount')
-      $scope.outcomeDetail = FsInfoService.t('conditionspreventedus')
+      var msg = FsBankService.getResponseStatusMessage(fs.consentResponse)
+      if (msg && msg !== 'OK' && msg !== 'ERROR') {
+        // OK should never appear at this point and ERROR is too generic
+        $scope.outcome = 'ERROR'
+        $scope.outcomeDetail = msg
+      } else {
+        $scope.outcome = FsInfoService.t('inaccessibleaccount')
+        $scope.outcomeDetail = FsInfoService.t('conditionspreventedus')
 
-      var reasons = {}
-      _.each(['datamismatch', 'notbarclays', 'frozen', 'businessacc', 'accountclosed'], function (f) {
-        reasons[f] = FsInfoService.t(f)
-      })
-      $scope.reasons = reasons
+        var reasons = {}
+        _.each(['datamismatch', 'notbarclays', 'frozen', 'businessacc', 'accountclosed'], function (f) {
+          reasons[f] = FsInfoService.t(f)
+        })
+        $scope.reasons = reasons
 
-      $scope.doNext = [FsInfoService.t('checkDataEntry')]
+        $scope.doNext = [FsInfoService.t('checkDataEntry')]
+      }
   }
 }])

--- a/src/app/modules/fs/fsBank.js
+++ b/src/app/modules/fs/fsBank.js
@@ -77,6 +77,14 @@ fsModule.factory('FsBankService', ['IOService', 'FsInfoService', function (IOSer
     return IOService.get(u, params)
   }
 
+  this.getResponseStatusMessage = function (obj) {
+    if (_.has(obj, 'data') && _.has(obj.data, 'status') && _.has(obj.data.status, 'message')) {
+      return obj.data.status.message
+    }
+
+    return null
+  }
+
   // get daily balance status url
   this.getDailyBalanceStatusUrl = function (obj) {
     if (!obj.tier || !obj.sortCode || !obj.accountNumber) {

--- a/src/app/modules/fs/templates/fsNav.html
+++ b/src/app/modules/fs/templates/fsNav.html
@@ -15,5 +15,6 @@
   <a ng-click="setBank('00000505')">ERROR</a>
   <a ng-click="setBank('00000506')">404</a>
   <a ng-click="setBank('27272727')">RECORDS</a>
+  <a ng-click="setBank('00000507')">MOBILE</a>
 </div>
 <hod-availability></hod-availability>


### PR DESCRIPTION
Extra error message text can be supplied through the json response.
eg
`
{
    "accountHolderName" : "Ray Purchase",
    "pass" : false,
    "failureReason" : {
    },
    "status" : {
        "code" : "470",
        "message" : "Mobile number has been updated within 14 days"
    }
}
`