### PR TITLE
Ee 21542 whitelist dev envs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -61,6 +61,7 @@ pipeline:
       - ENVIRONMENT=dev
       - VERSION=build-${DRONE_BUILD_NUMBER}
       - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+      - WHITELIST=62.25.109.196/32,52.48.127.150/32,52.48.127.151/32,52.48.127.152/32,52.48.127.153/32,52.209.62.128/25,52.56.62.128/25,185.22.224.96,185.22.224.96/32,185.22.226.96/32,213.251.23.180/30,213.251.23.184/30,213.251.23.188/30,148.253.134.213/32,167.98.162.0/25,167.98.158.128/25
     secrets:
       - pttg_fs_dev
     commands:
@@ -76,6 +77,7 @@ pipeline:
       - KUBE_NAMESPACE=pttg-fs-${DRONE_DEPLOY_TO}
       - ENVIRONMENT=${DRONE_DEPLOY_TO}
       - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+      - WHITELIST=62.25.109.196/32,52.48.127.150/32,52.48.127.151/32,52.48.127.152/32,52.48.127.153/32,52.209.62.128/25,52.56.62.128/25,185.22.224.96,185.22.224.96/32,185.22.226.96/32,213.251.23.180/30,213.251.23.184/30,213.251.23.188/30,148.253.134.213/32,167.98.162.0/25,167.98.158.128/25
     secrets:
       - pttg_fs_dev
       - pttg_fs_test

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ pipeline:
     commands:
       - docker build -t pttg-fs-ui .
     when:
-      branch: [master, EE-21542-whitelist-dev-envs]
+      branch: master
       event: push
 
   test:
@@ -31,7 +31,7 @@ pipeline:
       - docker tag pttg-fs-ui quay.io/ukhomeofficedigital/pttg-fs-ui:build-$${DRONE_BUILD_NUMBER}
       - docker push quay.io/ukhomeofficedigital/pttg-fs-ui:build-$${DRONE_BUILD_NUMBER}
     when:
-      branch: [master, EE-21542-whitelist-dev-envs]
+      branch: master
       event: push
 
   tag-docker-image-with-git-tag:
@@ -68,7 +68,7 @@ pipeline:
       - cd kube-pttg-fs-ui
       - ./deploy.sh
     when:
-      branch: [master, EE-21542-whitelist-dev-envs]
+      branch: master
       event: [push, tag]
 
   deployment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ pipeline:
     commands:
       - docker build -t pttg-fs-ui .
     when:
-      branch: master
+      branch: [master, EE-21542-whitelist-dev-envs]
       event: push
 
   test:
@@ -31,7 +31,7 @@ pipeline:
       - docker tag pttg-fs-ui quay.io/ukhomeofficedigital/pttg-fs-ui:build-$${DRONE_BUILD_NUMBER}
       - docker push quay.io/ukhomeofficedigital/pttg-fs-ui:build-$${DRONE_BUILD_NUMBER}
     when:
-      branch: master
+      branch: [master, EE-21542-whitelist-dev-envs]
       event: push
 
   tag-docker-image-with-git-tag:
@@ -68,7 +68,7 @@ pipeline:
       - cd kube-pttg-fs-ui
       - ./deploy.sh
     when:
-      branch: master
+      branch: [master, EE-21542-whitelist-dev-envs]
       event: [push, tag]
 
   deployment:


### PR DESCRIPTION
Add same IP address whitelist to FS UI that we use in IPS and Enquiry Form.

I won't merge this when approved. I will stick it on the PR. But in my opinion the easiest way to test this is to merge it and check that the Dev/Test environments are accessible from Gov WiFi but not from an external IP address.