### PR TITLE
Ee 15890 image scan

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,7 +15,6 @@ pipeline:
     commands:
       - docker build -t pttg-fs-ui .
     when:
-      branch: master
       event: push
 
   scan:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,13 @@
 pipeline:
 
+  npm-audit:
+    image: node:12
+    commands:
+      # TODO EE-29064 remove skip so that build fails for new errors.
+      - npm audit --audit-level=moderate --only=prod || echo Temporarily skipping failure until EE-29064 is resolved
+    when:
+      event: push
+
   build-docker-image:
     image: docker:17.09.1
     environment:
@@ -8,6 +16,17 @@ pipeline:
       - docker build -t pttg-fs-ui .
     when:
       branch: master
+      event: push
+
+  scan:
+    image: quay.io/ukhomeofficedigital/anchore-submission:latest
+    dockerfile: Dockerfile
+    image_name: pttg-fs-ui
+    local_image: true
+    tolerate: medium
+    show_all_vulnerabilities: true
+    fail_on_detection: false # TODO EE-29064 Remove this when current vulnerabilities are resolved
+    when:
       event: push
 
   test:


### PR DESCRIPTION
Added vulnerability scanning to the build. It will not fail when vulnerabilities are found as we need to sort EE-29064 first. In order to give us a scan the image, I have made the feature-branch build perform a 'docker build'.

As this is a build change only I intend to merge once approved.